### PR TITLE
Fixes issues #5 (sign error in Langevin Eqs.)

### DIFF
--- a/quantumnetworks/systems/doublemode.py
+++ b/quantumnetworks/systems/doublemode.py
@@ -1,5 +1,5 @@
 """
-Driven Signle Mode System
+Driven Double-Mode Linear System with Beam-Splitter Coupling
 """
 from typing import Dict
 import numpy as np
@@ -21,13 +21,13 @@ class DoubleModeSystem(SystemSolver):
 
     def _param_validation(self):
         if "omega_a" not in self.params:
-            self.params["omega_a"] = 1  # Ghz
+            self.params["omega_a"] = 1  # GHz
         if "omega_b" not in self.params:
-            self.params["omega_b"] = 2  # Ghz
+            self.params["omega_b"] = 2  # GHz
         if "kappa_a" not in self.params:
-            self.params["kappa_a"] = 0.001  # Ghz
+            self.params["kappa_a"] = 0.001  # GHz
         if "kappa_b" not in self.params:
-            self.params["kappa_b"] = 0.005  # Ghz
+            self.params["kappa_b"] = 0.005  # GHz
         if "g_ab" not in self.params:
             self.params["g_ab"] = 0.002  # GHz
 
@@ -44,10 +44,10 @@ class DoubleModeSystem(SystemSolver):
             g_ab = self.params["g_ab"]
 
             A = np.zeros((4, 4))
-            A[0, 0] = kappa_a / 2
-            A[1, 1] = kappa_a / 2
-            A[2, 2] = kappa_b / 2
-            A[3, 3] = kappa_b / 2
+            A[0, 0] = -kappa_a / 2
+            A[1, 1] = -kappa_a / 2
+            A[2, 2] = -kappa_b / 2
+            A[3, 3] = -kappa_b / 2
 
             A[0, 1] = omega_a
             A[1, 0] = -omega_a
@@ -67,10 +67,10 @@ class DoubleModeSystem(SystemSolver):
             kappa_a = self.params["kappa_a"]
             kappa_b = self.params["kappa_b"]
             B = np.zeros((4, 4))
-            B[0, 0] = np.sqrt(kappa_a)
-            B[1, 1] = np.sqrt(kappa_a)
-            B[2, 2] = np.sqrt(kappa_b)
-            B[3, 3] = np.sqrt(kappa_b)
+            B[0, 0] = -np.sqrt(kappa_a)
+            B[1, 1] = -np.sqrt(kappa_a)
+            B[2, 2] = -np.sqrt(kappa_b)
+            B[3, 3] = -np.sqrt(kappa_b)
             self._B = B
         return self._B
 

--- a/quantumnetworks/systems/multimode.py
+++ b/quantumnetworks/systems/multimode.py
@@ -1,5 +1,5 @@
 """
-Driven Signle Mode System
+Driven Multi-Mode Mode Linear System with Beam-Splitter Couplings
 """
 from typing import Dict, Any, List
 import numpy as np
@@ -108,8 +108,8 @@ class MultiModeSystem(SystemSolver):
 
             # kappas
             for i, kappa in enumerate(kappas):
-                A[2 * i, 2 * i] = kappa / 2
-                A[2 * i + 1, 2 * i + 1] = kappa / 2
+                A[2 * i, 2 * i] = -kappa / 2
+                A[2 * i + 1, 2 * i + 1] = -kappa / 2
 
             # couplings
             for i in range(couplings.shape[0]):
@@ -134,8 +134,8 @@ class MultiModeSystem(SystemSolver):
             B = np.zeros((num_modes * 2, num_drives * 2))
             for i, kappa in enumerate(kappas):
                 if kappa != 0:
-                    B[2 * i, 2 * i] = np.sqrt(kappa)
-                    B[2 * i + 1, 2 * i + 1] = np.sqrt(kappa)
+                    B[2 * i, 2 * i] = -np.sqrt(kappa)
+                    B[2 * i + 1, 2 * i + 1] = -np.sqrt(kappa)
 
             self._B = B
         return self._B

--- a/quantumnetworks/systems/singlemode.py
+++ b/quantumnetworks/systems/singlemode.py
@@ -1,5 +1,5 @@
 """
-Driven Signle Mode System
+Driven Single Mode Linear System
 """
 from typing import Dict, Any
 import numpy as np
@@ -33,7 +33,7 @@ class SingleModeSystem(SystemSolver):
             omega_a = self.params["omega_a"]
             kappa_a = self.params["kappa_a"]
 
-            A = np.array([[kappa_a / 2, omega_a], [-omega_a, kappa_a / 2]])
+            A = np.array([[-kappa_a / 2, omega_a], [-omega_a, -kappa_a / 2]])
             self._A = A
         return self._A
 
@@ -41,7 +41,7 @@ class SingleModeSystem(SystemSolver):
     def B(self):
         if self._B is None:
             kappa_a = self.params["kappa_a"]
-            B = np.array([[np.sqrt(kappa_a), 0], [0, np.sqrt(kappa_a)]])
+            B = np.array([[-np.sqrt(kappa_a), 0], [0, -np.sqrt(kappa_a)]])
             self._B = B
         return self._B
 


### PR DESCRIPTION
This PR closes issue [#5]. Added in minus signs to all kappa terms in the `A` and `B` stamping methods of `SingleModeSystem`, `DoubleModeSystem`, and `MultiModeSystem`. Also fixed 1-2 misc. typos. 